### PR TITLE
Fix build on 32bit environment

### DIFF
--- a/co2monitor/co2monitor.go
+++ b/co2monitor/co2monitor.go
@@ -53,7 +53,7 @@ func Open(name string) (c Conn, err error) {
 	for i, v := range key {
 		setReport[i+1] = v
 	}
-	hidiocsfeature9 := 0xC0094806
+	const hidiocsfeature9 = 0xC0094806
 	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, device.Fd(), uintptr(hidiocsfeature9), uintptr(unsafe.Pointer(setReport)))
 	if ep != 0 {
 		device.Close()


### PR DESCRIPTION
hidiocsfeature9 is implicitly int, and it fails to build on 32bit
environment:

$ GOOS=linux GOARCH=386 go build ./co2monitor
github.com/markuslindenberg/co2monitor_exporter/co2monitor
co2monitor/co2monitor.go:56:18: constant 3221833734 overflows int

To avoid this issue this patch simply converts hidiocsfeature9 to
an untyped integer constant.